### PR TITLE
Dynamic compression for world data

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation("com.github.GTNewHorizons:GTNHLib:0.11.24:dev")
     implementation("com.github.GTNewHorizons:RegionLib:v0.1.0-GTNH:dev")
 
+    shadowImplementation("at.yawk.lz4:lz4-java:1.11.0")
+
 //    runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.8.0:dev")
 
     compileOnly("org.jetbrains:annotations:26.0.2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -130,7 +130,7 @@ forceEnableMixins = false
 
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated into your jar. It is your
 # responsibility to check the license and request permission for distribution if required.
-usesShadowedDependencies = false
+usesShadowedDependencies = true
 
 # If disabled, won't remove unused classes from shadowed dependencies. Some libraries use reflection to access
 # their own classes, making the minimization unreliable.

--- a/gradle.properties
+++ b/gradle.properties
@@ -134,7 +134,7 @@ usesShadowedDependencies = true
 
 # If disabled, won't remove unused classes from shadowed dependencies. Some libraries use reflection to access
 # their own classes, making the minimization unreliable.
-minimizeShadowedDependencies = true
+minimizeShadowedDependencies = false
 
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true

--- a/src/main/java/com/cardinalstar/cubicchunks/CubicChunksConfig.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/CubicChunksConfig.java
@@ -29,6 +29,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import net.minecraft.block.Block;
 
+import com.cardinalstar.cubicchunks.server.chunkio.CCNBTUtils.TagCompression;
 import com.cardinalstar.cubicchunks.worldgen.FillerInfo;
 import com.cardinalstar.cubicchunks.worldgen.HeightInfo;
 import com.gtnewhorizon.gtnhlib.config.Config;
@@ -141,6 +142,10 @@ public class CubicChunksConfig {
     @Config.LangKey("cubicchunks.config.disable_lighting")
     @Config.Comment("Disables all light propagation")
     public static boolean disableLighting = false;
+
+    @Config.LangKey("cubicchunks.config.chunk_compression")
+    @Config.Comment("Controls the default compression algorithm used for chunks and cubes. Can be changed arbitrarily without corrupting worlds.")
+    public static TagCompression chunkCompression = TagCompression.LZ4;
 
     @Config.Ignore
     public static int defaultMaxCubesPerChunkloadingTicket = 25 * 16;

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
@@ -94,6 +94,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("common.MixinWorld_DeferInit", "common.MixinWorld_DeferInit$MixinWorldServer")
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> true)),
+    ACCESSOR_NBT(new MixinBuilder("Add accessors for NBT tag internals.")
+        .addCommonMixins("common.AccessorNBTTagList", "common.AccessorNBTTagCompound")
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> true)),
 
     // CHUNK
     MIXIN_CHUNK(new MixinBuilder("Various modifications to inject cubes, height map patches, etc into Chunks.")

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/AccessorNBTTagCompound.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/AccessorNBTTagCompound.java
@@ -1,0 +1,17 @@
+package com.cardinalstar.cubicchunks.mixin.early.common;
+
+import java.util.Map;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(NBTTagCompound.class)
+public interface AccessorNBTTagCompound {
+
+    @Accessor("tagMap")
+    Map<String, NBTBase> getTagMap();
+
+}

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/AccessorNBTTagList.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/AccessorNBTTagList.java
@@ -1,0 +1,17 @@
+package com.cardinalstar.cubicchunks.mixin.early.common;
+
+import java.util.List;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagList;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(NBTTagList.class)
+public interface AccessorNBTTagList {
+
+    @Accessor("tagList")
+    List<NBTBase> getTagList();
+
+}

--- a/src/main/java/com/cardinalstar/cubicchunks/network/PacketEncoderCube.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/network/PacketEncoderCube.java
@@ -22,6 +22,7 @@ package com.cardinalstar.cubicchunks.network;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import net.jpountz.lz4.LZ4Factory;
 import net.minecraft.world.World;
 
 import com.cardinalstar.cubicchunks.CubicChunks;
@@ -32,9 +33,9 @@ import com.cardinalstar.cubicchunks.util.CubeStatusVisualizer;
 import com.cardinalstar.cubicchunks.util.CubeStatusVisualizer.CubeStatus;
 import com.cardinalstar.cubicchunks.world.cube.Cube;
 import com.github.bsideup.jabel.Desugar;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import net.jpountz.lz4.LZ4Factory;
 
 @ParametersAreNonnullByDefault
 public class PacketEncoderCube extends CCPacketEncoder<PacketCube> {

--- a/src/main/java/com/cardinalstar/cubicchunks/network/PacketEncoderCube.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/network/PacketEncoderCube.java
@@ -32,9 +32,9 @@ import com.cardinalstar.cubicchunks.util.CubeStatusVisualizer;
 import com.cardinalstar.cubicchunks.util.CubeStatusVisualizer.CubeStatus;
 import com.cardinalstar.cubicchunks.world.cube.Cube;
 import com.github.bsideup.jabel.Desugar;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import net.jpountz.lz4.LZ4Factory;
 
 @ParametersAreNonnullByDefault
 public class PacketEncoderCube extends CCPacketEncoder<PacketCube> {
@@ -73,16 +73,25 @@ public class PacketEncoderCube extends CCPacketEncoder<PacketCube> {
     public void writePacket(CCPacketBuffer buffer, PacketCube packet) {
         buffer.writeCubePos(packet.cubePos);
 
-        buffer.writeByteArray(packet.data);
+        buffer.writeVarIntToBuffer(packet.data.length);
+        buffer.writeByteArray(
+            LZ4Factory.fastestInstance()
+                .fastCompressor()
+                .compress(packet.data));
     }
 
     @Override
     public PacketCube readPacket(CCPacketBuffer buf) {
         CubePos pos = buf.readCubePos();
 
+        byte[] decompressed = new byte[buf.readVarIntFromBuffer()];
         byte[] data = buf.readByteArray();
 
-        return new PacketCube(pos, data);
+        LZ4Factory.fastestInstance()
+            .fastDecompressor()
+            .decompress(data, decompressed);
+
+        return new PacketCube(pos, decompressed);
     }
 
     @Override

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
@@ -1,50 +1,185 @@
 package com.cardinalstar.cubicchunks.server.chunkio;
 
-import java.io.ByteArrayInputStream;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTSizeTracker;
+import net.minecraft.nbt.NBTTagByteArray;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagIntArray;
+import net.minecraft.nbt.NBTTagString;
+import net.minecraftforge.common.util.Constants.NBT;
 
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
+
+import com.cardinalstar.cubicchunks.mixin.early.common.AccessorNBTTagCompound;
+import com.cardinalstar.cubicchunks.mixin.early.common.AccessorNBTTagList;
+import com.cardinalstar.cubicchunks.util.ByteBufferInputStream;
+import com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities;
+import net.jpountz.lz4.LZ4Factory;
 
 public class CCNBTUtils {
 
-    public static NBTTagCompound loadTag(byte[] data) throws IOException {
-        if (data[0] == (byte) 0x1f && data[1] == (byte) 0x8b) {
-            try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(data));) {
-                data = IOUtils.toByteArray(gzip);
+    public static final int GZIP_MAGIC_NUMBER = 0x8b1F;
+    public static final int LZ4_MAGIC_NUMBER = 0x184D2204;
+
+    public static NBTTagCompound loadTag(ByteBuffer data) throws IOException {
+        data.order(ByteOrder.LITTLE_ENDIAN);
+
+        if ((data.getShort(0) & 0xFFFF) == GZIP_MAGIC_NUMBER) {
+            try (var input = new GZIPInputStream(new ByteBufferInputStream(data))) {
+                try (DataInputStream dis = new DataInputStream(new BufferedInputStream(input))) {
+                    return CompressedStreamTools.func_152456_a(dis, NBTSizeTracker.field_152451_a);
+                }
             }
         }
 
-        return CompressedStreamTools
-            .func_152456_a(new DataInputStream(new ByteArrayInputStream(data)), NBTSizeTracker.field_152451_a);
+        if (data.getInt(0) == LZ4_MAGIC_NUMBER) {
+            int decompLen = data.getInt(4);
+
+            ByteBuffer decompressed = MemoryUtilities.memAlloc(decompLen);
+
+            try {
+                LZ4Factory.fastestInstance().fastDecompressor().decompress(data, 8, decompressed, 0, decompLen);
+
+                decompressed.limit(decompLen);
+
+                try (DataInputStream dos = new DataInputStream(new ByteBufferInputStream(decompressed))) {
+                    return CompressedStreamTools.func_152456_a(dos, NBTSizeTracker.field_152451_a);
+                }
+            } finally {
+                MemoryUtilities.memFree(decompressed);
+            }
+        }
+
+        throw new RuntimeException("Unknown NBT tag byte format; your world is likely corrupted");
     }
 
-    public static byte[] saveTag(NBTTagCompound tag, boolean compress) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    public enum TagCompression {
+        GZIP,
+        FastLZ4,
+    }
 
-        CompressedStreamTools.write(tag, new DataOutputStream(baos));
+    public static ByteBuffer saveTag(NBTTagCompound tag, TagCompression compression) throws IOException {
+        switch (compression) {
+            case GZIP -> {
+                try (ByteArrayOutputStream nos = new ByteArrayOutputStream(getTagSizeEstimate(tag))) {
+                    try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(new GZIPOutputStream2(nos)))) {
+                        CompressedStreamTools.write(tag, dos);
+                    }
 
-        byte[] data = baos.toByteArray();
-
-        if (compress) {
-            ByteArrayOutputStream zipped = new ByteArrayOutputStream(data.length);
-
-            try (GZIPOutputStream zipstream = new GZIPOutputStream(zipped)) {
-                IOUtils.write(data, zipstream);
-                zipstream.flush();
+                    return ByteBuffer.wrap(nos.toByteArray()).order(ByteOrder.LITTLE_ENDIAN);
+                }
             }
+            case FastLZ4 -> {
+                try (ByteArrayOutputStream nos = new ByteArrayOutputStream(getTagSizeEstimate(tag))) {
+                    try (DataOutputStream dos = new DataOutputStream(nos)) {
+                        CompressedStreamTools.write(tag, dos);
+                    }
 
-            data = zipped.toByteArray();
+                    byte[] data = nos.toByteArray();
+
+                    ByteBuffer compressed = ByteBuffer.allocate(data.length + 8).order(ByteOrder.LITTLE_ENDIAN);
+
+                    int compLen = LZ4Factory.fastestInstance().fastCompressor().compress(data, 0, data.length, compressed.array(), 8);
+
+                    compressed.putInt(0, LZ4_MAGIC_NUMBER);
+                    compressed.putInt(4, data.length);
+                    compressed.limit(8 + compLen);
+
+                    return compressed;
+                }
+            }
+            default -> {
+                throw new AssertionError("Illegal compression level: " + compression);
+            }
+        }
+    }
+
+    private static int getTagSizeEstimate(NBTBase tag) {
+        switch (tag.getId()) {
+            case NBT.TAG_BYTE -> {
+                return 2;
+            }
+            case NBT.TAG_SHORT -> {
+                return 3;
+            }
+            case NBT.TAG_INT -> {
+                return 5;
+            }
+            case NBT.TAG_LONG -> {
+                return 9;
+            }
+            case NBT.TAG_FLOAT -> {
+                return 5;
+            }
+            case NBT.TAG_DOUBLE -> {
+                return 9;
+            }
+            case NBT.TAG_BYTE_ARRAY -> {
+                return 5 + ((NBTTagByteArray) tag).func_150292_c().length;
+            }
+            case NBT.TAG_INT_ARRAY -> {
+                return 5 + ((NBTTagIntArray) tag).func_150302_c().length * 4;
+            }
+            case NBT.TAG_STRING -> {
+                return 1 + ((NBTTagString) tag).func_150285_a_()
+                    .length() * 2;
+            }
+            case NBT.TAG_LIST -> {
+                var list = ((AccessorNBTTagList) tag).getTagList();
+
+                int len = list.size();
+
+                int size = 5;
+
+                for (int i = 0; i < len; i++) {
+                    size += getTagSizeEstimate(list.get(i));
+                }
+
+                return size;
+            }
+            case NBT.TAG_COMPOUND -> {
+                var map = ((AccessorNBTTagCompound) tag).getTagMap();
+
+                MutableInt size = new MutableInt(5);
+
+                map.forEach((key, value) -> {
+                    size.add(key.length() * 2);
+                    size.add(getTagSizeEstimate(value));
+                });
+
+                return size.intValue();
+            }
+            default -> {
+                return 1;
+            }
+        }
+    }
+
+    private static class GZIPOutputStream2 extends GZIPOutputStream {
+
+        private final byte[] pooled;
+
+        public GZIPOutputStream2(ByteArrayOutputStream nos) throws IOException {
+            super(nos);
+            pooled = new byte[1];
         }
 
-        return data;
+        @Override
+        public void write(int b) throws IOException {
+            pooled[0] = (byte) (b & 0xff);
+            write(pooled, 0, 1);
+        }
     }
 }

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
@@ -11,6 +11,7 @@ import java.nio.ByteOrder;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import net.jpountz.lz4.LZ4Factory;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTSizeTracker;
@@ -26,7 +27,6 @@ import com.cardinalstar.cubicchunks.mixin.early.common.AccessorNBTTagCompound;
 import com.cardinalstar.cubicchunks.mixin.early.common.AccessorNBTTagList;
 import com.cardinalstar.cubicchunks.util.ByteBufferInputStream;
 import com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities;
-import net.jpountz.lz4.LZ4Factory;
 
 public class CCNBTUtils {
 
@@ -50,7 +50,9 @@ public class CCNBTUtils {
             ByteBuffer decompressed = MemoryUtilities.memAlloc(decompLen);
 
             try {
-                LZ4Factory.fastestInstance().fastDecompressor().decompress(data, 8, decompressed, 0, decompLen);
+                LZ4Factory.fastestInstance()
+                    .fastDecompressor()
+                    .decompress(data, 8, decompressed, 0, decompLen);
 
                 decompressed.limit(decompLen);
 
@@ -74,11 +76,13 @@ public class CCNBTUtils {
         switch (compression) {
             case GZIP -> {
                 try (ByteArrayOutputStream nos = new ByteArrayOutputStream(getTagSizeEstimate(tag))) {
-                    try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(new GZIPOutputStream2(nos)))) {
+                    try (DataOutputStream dos = new DataOutputStream(
+                        new BufferedOutputStream(new GZIPOutputStream2(nos)))) {
                         CompressedStreamTools.write(tag, dos);
                     }
 
-                    return ByteBuffer.wrap(nos.toByteArray()).order(ByteOrder.LITTLE_ENDIAN);
+                    return ByteBuffer.wrap(nos.toByteArray())
+                        .order(ByteOrder.LITTLE_ENDIAN);
                 }
             }
             case FastLZ4 -> {
@@ -89,9 +93,12 @@ public class CCNBTUtils {
 
                     byte[] data = nos.toByteArray();
 
-                    ByteBuffer compressed = ByteBuffer.allocate(data.length + 8).order(ByteOrder.LITTLE_ENDIAN);
+                    ByteBuffer compressed = ByteBuffer.allocate(data.length + 8)
+                        .order(ByteOrder.LITTLE_ENDIAN);
 
-                    int compLen = LZ4Factory.fastestInstance().fastCompressor().compress(data, 0, data.length, compressed.array(), 8);
+                    int compLen = LZ4Factory.fastestInstance()
+                        .fastCompressor()
+                        .compress(data, 0, data.length, compressed.array(), 8);
 
                     compressed.putInt(0, LZ4_MAGIC_NUMBER);
                     compressed.putInt(4, data.length);

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
@@ -66,7 +66,8 @@ public class CCNBTUtils {
             }
         }
 
-        if (data.getLong(0) == NONE_MAGIC_NUMBER_UUID.getLeastSignificantBits() && data.getLong(8) == NONE_MAGIC_NUMBER_UUID.getMostSignificantBits()) {
+        if (data.getLong(0) == NONE_MAGIC_NUMBER_UUID.getLeastSignificantBits()
+            && data.getLong(8) == NONE_MAGIC_NUMBER_UUID.getMostSignificantBits()) {
             data.position(16);
 
             try (DataInputStream dos = new DataInputStream(new ByteBufferInputStream(data))) {

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
@@ -8,6 +8,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.UUID;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -32,6 +33,7 @@ public class CCNBTUtils {
 
     public static final int GZIP_MAGIC_NUMBER = 0x8b1F;
     public static final int LZ4_MAGIC_NUMBER = 0x184D2204;
+    public static final UUID NONE_MAGIC_NUMBER_UUID = UUID.fromString("904e51a4-3ee3-478c-92ee-db5a0af9ecc0");
 
     public static NBTTagCompound loadTag(ByteBuffer data) throws IOException {
         data.order(ByteOrder.LITTLE_ENDIAN);
@@ -64,12 +66,21 @@ public class CCNBTUtils {
             }
         }
 
+        if (data.getLong(0) == NONE_MAGIC_NUMBER_UUID.getLeastSignificantBits() && data.getLong(8) == NONE_MAGIC_NUMBER_UUID.getMostSignificantBits()) {
+            data.position(16);
+
+            try (DataInputStream dos = new DataInputStream(new ByteBufferInputStream(data))) {
+                return CompressedStreamTools.func_152456_a(dos, NBTSizeTracker.field_152451_a);
+            }
+        }
+
         throw new RuntimeException("Unknown NBT tag byte format; your world is likely corrupted");
     }
 
     public enum TagCompression {
         GZIP,
-        FastLZ4,
+        LZ4,
+        NONE,
     }
 
     public static ByteBuffer saveTag(NBTTagCompound tag, TagCompression compression) throws IOException {
@@ -85,7 +96,7 @@ public class CCNBTUtils {
                         .order(ByteOrder.LITTLE_ENDIAN);
                 }
             }
-            case FastLZ4 -> {
+            case LZ4 -> {
                 try (ByteArrayOutputStream nos = new ByteArrayOutputStream(getTagSizeEstimate(tag))) {
                     try (DataOutputStream dos = new DataOutputStream(nos)) {
                         CompressedStreamTools.write(tag, dos);
@@ -105,6 +116,18 @@ public class CCNBTUtils {
                     compressed.limit(8 + compLen);
 
                     return compressed;
+                }
+            }
+            case NONE -> {
+                try (ByteArrayOutputStream nos = new ByteArrayOutputStream(getTagSizeEstimate(tag))) {
+                    try (DataOutputStream dos = new DataOutputStream(nos)) {
+                        dos.writeLong(Long.reverseBytes(NONE_MAGIC_NUMBER_UUID.getLeastSignificantBits()));
+                        dos.writeLong(Long.reverseBytes(NONE_MAGIC_NUMBER_UUID.getMostSignificantBits()));
+
+                        CompressedStreamTools.write(tag, dos);
+                    }
+
+                    return ByteBuffer.wrap(nos.toByteArray());
                 }
             }
             default -> {

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
@@ -104,13 +104,13 @@ public class CCNBTUtils {
                     }
 
                     byte[] data = nos.toByteArray();
+                    var compressor = LZ4Factory.fastestInstance()
+                        .fastCompressor();
 
-                    ByteBuffer compressed = ByteBuffer.allocate(data.length + 8)
+                    ByteBuffer compressed = ByteBuffer.allocate(8 + compressor.maxCompressedLength(data.length))
                         .order(ByteOrder.LITTLE_ENDIAN);
 
-                    int compLen = LZ4Factory.fastestInstance()
-                        .fastCompressor()
-                        .compress(data, 0, data.length, compressed.array(), 8);
+                    int compLen = compressor.compress(data, 0, data.length, compressed.array(), 8);
 
                     compressed.putInt(0, LZ4_MAGIC_NUMBER);
                     compressed.putInt(4, data.length);

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
@@ -204,7 +204,7 @@ public class RegionCubeStorage implements ICubicStorage {
 
     @Override
     public void writeColumn(ChunkCoordIntPair pos, NBTTagCompound nbt) throws IOException {
-        ByteBuffer compressed = CCNBTUtils.saveTag(nbt, TagCompression.FastLZ4);
+        ByteBuffer compressed = CCNBTUtils.saveTag(nbt, CubicChunksConfig.chunkCompression);
 
         // write compressed data to disk
         this.save.save2d(new EntryLocation2D(pos.chunkXPos, pos.chunkZPos), compressed);
@@ -212,7 +212,7 @@ public class RegionCubeStorage implements ICubicStorage {
 
     @Override
     public void writeCube(CubePos pos, NBTTagCompound nbt) throws IOException {
-        ByteBuffer compressed = CCNBTUtils.saveTag(nbt, TagCompression.FastLZ4);
+        ByteBuffer compressed = CCNBTUtils.saveTag(nbt, CubicChunksConfig.chunkCompression);
 
         // write compressed data to disk
         this.save.save3d(new EntryLocation3D(pos.getX(), pos.getY(), pos.getZ()), compressed);
@@ -246,7 +246,7 @@ public class RegionCubeStorage implements ICubicStorage {
                 .parallelStream()
                 .collect(Collectors.toMap(entry -> keyMappingFunction.apply(entry.getKey()), entry -> {
                     try {
-                        return CCNBTUtils.saveTag(entry.getValue(), TagCompression.FastLZ4);
+                        return CCNBTUtils.saveTag(entry.getValue(), CubicChunksConfig.chunkCompression);
                     } catch (IOException e) {
                         // wrap exception so that we can throw it from inside the lambda
                         throw new UncheckedIOException(e);

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
@@ -27,13 +27,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.ChunkCoordIntPair;
 
@@ -41,10 +39,10 @@ import org.jetbrains.annotations.NotNull;
 
 import com.cardinalstar.cubicchunks.CubicChunksConfig;
 import com.cardinalstar.cubicchunks.api.world.storage.ICubicStorage;
+import com.cardinalstar.cubicchunks.server.chunkio.CCNBTUtils.TagCompression;
 import com.cardinalstar.cubicchunks.server.chunkio.region.ShadowPagingRegion;
 import com.cardinalstar.cubicchunks.util.CubePos;
 import com.cardinalstar.cubicchunks.util.DataUtils;
-
 import cubicchunks.regionlib.impl.EntryLocation2D;
 import cubicchunks.regionlib.impl.EntryLocation3D;
 import cubicchunks.regionlib.impl.SaveCubeColumns;
@@ -54,9 +52,6 @@ import cubicchunks.regionlib.lib.ExtRegion;
 import cubicchunks.regionlib.lib.factory.SimpleRegionFactory;
 import cubicchunks.regionlib.lib.provider.SharedCachedRegionProvider;
 import cubicchunks.regionlib.util.Utils;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
-import io.netty.buffer.UnpooledByteBufAllocator;
 import it.unimi.dsi.fastutil.Pair;
 
 /**
@@ -121,11 +116,9 @@ public class RegionCubeStorage implements ICubicStorage {
         }
     }
 
-    private final Path path;
     private SaveCubeColumns save;
 
     public RegionCubeStorage(Path path) throws IOException {
-        this.path = Objects.requireNonNull(path, "path");
         this.save = saveForPath(path);
     }
 
@@ -150,8 +143,7 @@ public class RegionCubeStorage implements ICubicStorage {
         if (!data.isPresent()) return null;
 
         return CCNBTUtils.loadTag(
-            data.get()
-                .array());
+            data.get());
     }
 
     @Override
@@ -161,8 +153,7 @@ public class RegionCubeStorage implements ICubicStorage {
         if (!data.isPresent()) return null;
 
         return CCNBTUtils.loadTag(
-            data.get()
-                .array());
+            data.get());
     }
 
     @Override
@@ -184,8 +175,7 @@ public class RegionCubeStorage implements ICubicStorage {
                             e.getKey()
                                 .getEntryZ()),
                         CCNBTUtils.loadTag(
-                            e.getValue()
-                                .array()));
+                            e.getValue()));
                 } catch (IOException ex) {
                     throw new UncheckedIOException(ex);
                 }
@@ -205,8 +195,7 @@ public class RegionCubeStorage implements ICubicStorage {
                             e.getKey()
                                 .getEntryZ()),
                         CCNBTUtils.loadTag(
-                            e.getValue()
-                                .array()));
+                            e.getValue()));
                 } catch (IOException ex) {
                     throw new UncheckedIOException(ex);
                 }
@@ -218,73 +207,49 @@ public class RegionCubeStorage implements ICubicStorage {
 
     @Override
     public void writeColumn(ChunkCoordIntPair pos, NBTTagCompound nbt) throws IOException {
-        ByteBuf compressedBuf = UnpooledByteBufAllocator.DEFAULT.ioBuffer();
-        try {
-            // compress NBT data
-            CompressedStreamTools.writeCompressed(nbt, new ByteBufOutputStream(compressedBuf));
+        ByteBuffer compressed = CCNBTUtils.saveTag(nbt, TagCompression.FastLZ4);
 
-            // write compressed data to disk
-            this.save.save2d(new EntryLocation2D(pos.chunkXPos, pos.chunkZPos), compressedBuf.nioBuffer());
-        } finally {
-            compressedBuf.release();
-        }
+        // write compressed data to disk
+        this.save.save2d(new EntryLocation2D(pos.chunkXPos, pos.chunkZPos), compressed);
     }
 
     @Override
     public void writeCube(CubePos pos, NBTTagCompound nbt) throws IOException {
-        ByteBuf compressedBuf = UnpooledByteBufAllocator.DEFAULT.ioBuffer();
-        try {
-            // compress NBT data
-            CompressedStreamTools.writeCompressed(nbt, new ByteBufOutputStream(compressedBuf));
+        ByteBuffer compressed = CCNBTUtils.saveTag(nbt, TagCompression.FastLZ4);
 
-            // write compressed data to disk
-            this.save.save3d(new EntryLocation3D(pos.getX(), pos.getY(), pos.getZ()), compressedBuf.nioBuffer());
-        } finally {
-            compressedBuf.release();
-        }
+        // write compressed data to disk
+        this.save.save3d(new EntryLocation3D(pos.getX(), pos.getY(), pos.getZ()), compressed);
     }
 
     @Override
     public void writeBatch(NBTBatch batch) throws IOException {
-        Map<EntryLocation2D, byte[]> compressedColumns = Collections.emptyMap();
-        Map<EntryLocation3D, byte[]> compressedCubes = Collections.emptyMap();
         // compress NBT data
-        compressedColumns = this
+        var compressedColumns = this
             .compressNBTForBatchWrite(batch.columns, pos -> new EntryLocation2D(pos.chunkXPos, pos.chunkZPos));
-        compressedCubes = this
+        var compressedCubes = this
             .compressNBTForBatchWrite(batch.cubes, pos -> new EntryLocation3D(pos.getX(), pos.getY(), pos.getZ()));
 
         // write compressed data to disk
         if (!compressedColumns.isEmpty()) {
-            this.save.save2d(
-                compressedColumns.entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> ByteBuffer.wrap(entry.getValue()))));
+            this.save.save2d(compressedColumns);
         }
         if (!compressedCubes.isEmpty()) {
-            this.save.save3d(
-                compressedCubes.entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> ByteBuffer.wrap(entry.getValue()))));
+            this.save.save3d(compressedCubes);
         }
     }
 
-    private <KI, KO> Map<KO, byte[]> compressNBTForBatchWrite(Map<KI, NBTTagCompound> nbt,
+    private <KI, KO> Map<KO, ByteBuffer> compressNBTForBatchWrite(Map<KI, NBTTagCompound> nbt,
         Function<KI, KO> keyMappingFunction) throws IOException {
         if (nbt.isEmpty()) { // avoid somewhat expensive stream creation if there are no entries
             return Collections.emptyMap();
         }
 
         try {
-            // if the following code throws an exception, something is VERY wrong, so i won't bother with needlessly
-            // complex code to ensure that any
-            // previously allocated buffers get released in the event of an exception being thrown
-
             return nbt.entrySet()
                 .parallelStream()
                 .collect(Collectors.toMap(entry -> keyMappingFunction.apply(entry.getKey()), entry -> {
                     try {
-                        return CCNBTUtils.saveTag(entry.getValue(), true);
+                        return CCNBTUtils.saveTag(entry.getValue(), TagCompression.FastLZ4);
                     } catch (IOException e) {
                         // wrap exception so that we can throw it from inside the lambda
                         throw new UncheckedIOException(e);

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
@@ -39,7 +39,6 @@ import org.jetbrains.annotations.NotNull;
 
 import com.cardinalstar.cubicchunks.CubicChunksConfig;
 import com.cardinalstar.cubicchunks.api.world.storage.ICubicStorage;
-import com.cardinalstar.cubicchunks.server.chunkio.CCNBTUtils.TagCompression;
 import com.cardinalstar.cubicchunks.server.chunkio.region.ShadowPagingRegion;
 import com.cardinalstar.cubicchunks.util.CubePos;
 import com.cardinalstar.cubicchunks.util.DataUtils;

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/RegionCubeStorage.java
@@ -43,6 +43,7 @@ import com.cardinalstar.cubicchunks.server.chunkio.CCNBTUtils.TagCompression;
 import com.cardinalstar.cubicchunks.server.chunkio.region.ShadowPagingRegion;
 import com.cardinalstar.cubicchunks.util.CubePos;
 import com.cardinalstar.cubicchunks.util.DataUtils;
+
 import cubicchunks.regionlib.impl.EntryLocation2D;
 import cubicchunks.regionlib.impl.EntryLocation3D;
 import cubicchunks.regionlib.impl.SaveCubeColumns;
@@ -142,8 +143,7 @@ public class RegionCubeStorage implements ICubicStorage {
         Optional<ByteBuffer> data = this.save.load(new EntryLocation2D(pos.chunkXPos, pos.chunkZPos), true);
         if (!data.isPresent()) return null;
 
-        return CCNBTUtils.loadTag(
-            data.get());
+        return CCNBTUtils.loadTag(data.get());
     }
 
     @Override
@@ -152,8 +152,7 @@ public class RegionCubeStorage implements ICubicStorage {
         Optional<ByteBuffer> data = this.save.load(new EntryLocation3D(pos.getX(), pos.getY(), pos.getZ()), true);
         if (!data.isPresent()) return null;
 
-        return CCNBTUtils.loadTag(
-            data.get());
+        return CCNBTUtils.loadTag(data.get());
     }
 
     @Override
@@ -174,8 +173,7 @@ public class RegionCubeStorage implements ICubicStorage {
                                 .getEntryX(),
                             e.getKey()
                                 .getEntryZ()),
-                        CCNBTUtils.loadTag(
-                            e.getValue()));
+                        CCNBTUtils.loadTag(e.getValue()));
                 } catch (IOException ex) {
                     throw new UncheckedIOException(ex);
                 }
@@ -194,8 +192,7 @@ public class RegionCubeStorage implements ICubicStorage {
                                 .getEntryY(),
                             e.getKey()
                                 .getEntryZ()),
-                        CCNBTUtils.loadTag(
-                            e.getValue()));
+                        CCNBTUtils.loadTag(e.getValue()));
                 } catch (IOException ex) {
                     throw new UncheckedIOException(ex);
                 }

--- a/src/main/java/com/cardinalstar/cubicchunks/util/ByteBufferInputStream.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/util/ByteBufferInputStream.java
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer;
 import org.jetbrains.annotations.NotNull;
 
 public final class ByteBufferInputStream extends InputStream {
+
     private final ByteBuffer buffer;
 
     public ByteBufferInputStream(ByteBuffer buffer) {

--- a/src/main/java/com/cardinalstar/cubicchunks/util/ByteBufferInputStream.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/util/ByteBufferInputStream.java
@@ -1,0 +1,38 @@
+package com.cardinalstar.cubicchunks.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class ByteBufferInputStream extends InputStream {
+    private final ByteBuffer buffer;
+
+    public ByteBufferInputStream(ByteBuffer buffer) {
+        this.buffer = buffer;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (!buffer.hasRemaining()) {
+            return -1;
+        }
+        return buffer.get() & 0xFF;
+    }
+
+    @Override
+    public int read(byte @NotNull [] bytes, int off, int len) throws IOException {
+        if (!buffer.hasRemaining()) {
+            return -1;
+        }
+        int bytesToRead = Math.min(len, buffer.remaining());
+        buffer.get(bytes, off, bytesToRead);
+        return bytesToRead;
+    }
+
+    @Override
+    public int available() {
+        return buffer.remaining();
+    }
+}


### PR DESCRIPTION
- **LZ4 compress cube data**
- **Add NBT tag/list accessors for the internal maps/lists**
- **Compress saved tags with lz4 (optional)**
- **Forgot to add gradle.properties**
- **spotless**

## Summary
Chunk/cube saving unconditionally uses GZIP for compression currently. This PR adds the ability for data to be compressed with different algorithms. Currently, only LZ4 is implemented. LZ4 was chosen because it is extremely fast, which eliminates most overhead when loading or saving world data. The algorithm is configurable so that server owners can tweak it or disable it entirely. The compression level can be changed at-will, and the world will be re-compressed with the new format as chunks and cubes are re-saved. I will also add something that re-compresses rarely used chunks/cubes when players haven't visited them in several IRL days.

LZ4 compression was also added to cube data, since CC was uploading over 10MB/s to players as they moved. This should significantly reduce network usage while keeping overhead low. We previously used GZIP to compress packets, but its overhead made the game unplayable.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
