### PR TITLE
More misc fixes

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/lighting/FirstLightProcessor.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/lighting/FirstLightProcessor.java
@@ -149,6 +149,12 @@ public class FirstLightProcessor {
                     for (int yPos = minY; yPos <= bYMax; yPos++) {
                         if (yPos >= minInstantFill && yPos <= maxInstantFill) {
                             cube.setLightFor(EnumSkyBlock.Sky, bX + lX, yPos, bZ + lZ, 15);
+                        } else if (!isCubeEmpty && isEdge && yPos > stagingTopBlock) {
+                            // Above-terrain edge blocks have unambiguous sky access within their
+                            // own column. Instant-fill like vanilla instead of deferring to
+                            // Phosphor, otherwise the client would see sky=0 on the border until
+                            // the client lighting engine updates those blocks.
+                            cube.setLightFor(EnumSkyBlock.Sky, bX + lX, yPos, bZ + lZ, 15);
                         } else {
                             if (isEdge) {
                                 cube.setLightFor(EnumSkyBlock.Sky, bX + lX, yPos, bZ + lZ, 0);

--- a/src/main/java/com/cardinalstar/cubicchunks/lighting/LightingManager.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/lighting/LightingManager.java
@@ -199,6 +199,12 @@ public class LightingManager implements ILightingManager {
         }
         assert firstLightProcessor != null;
         firstLightProcessor.diffuseSkylight(cube);
+        // Drain the Phosphor queue immediately so that all light corrections are
+        // flushed into the EBS before the cube packet is sent to clients.
+        // Without this, Phosphor's deferred updates run after the packet is sent
+        // and are never communicated to the client (setLightValue does not call
+        // markBlockForUpdate - it only sets cube.isModified for disk persistence).
+        processUpdates();
     }
 
     /**

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
@@ -133,6 +133,8 @@ public class CubeLoaderServer implements ICubeLoader {
             throw new IllegalStateException("Cannot unload column that still contains cubes");
         }
 
+        column.column.onChunkUnload();
+
         columns.remove(column);
 
         column.onColumnUnloaded();
@@ -630,8 +632,6 @@ public class CubeLoaderServer implements ICubeLoader {
         }
 
         public void onColumnUnloaded() {
-            column.onChunkUnload();
-
             try {
                 cubeIO.saveColumn(pos, column);
             } finally {

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
@@ -135,6 +135,11 @@ public class CubeLoaderServer implements ICubeLoader {
 
         column.column.onChunkUnload();
 
+        for (var cube : new ArrayList<>(column.containedCubes)) {
+            cube.onCubeUnloaded();
+            cubes.remove(cube);
+        }
+
         columns.remove(column);
 
         column.onColumnUnloaded();

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/ICubeLoader.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/ICubeLoader.java
@@ -34,7 +34,7 @@ public interface ICubeLoader extends Flushable, Closeable {
 
     void setNow(long now);
 
-    default void cacheCubes(Box box, Requirement effort) {
+    default void cacheCubes(Box box) {
         cacheCubes(
             box.getX1(),
             box.getY1(),

--- a/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
@@ -69,7 +69,6 @@ import com.cardinalstar.cubicchunks.world.cube.blockview.IBlockView;
 import com.cardinalstar.cubicchunks.world.cube.blockview.UniformBlockView;
 import com.gtnewhorizon.gtnhlib.util.data.BlockMeta;
 import com.gtnewhorizon.gtnhlib.util.data.ImmutableBlockMeta;
-
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
@@ -407,9 +406,9 @@ public class VanillaWorldGenerator implements IWorldGenerator, IPreloadFailureDe
 
     private Box getCubesToGenerate(int x, int y, int z) {
         if (y >= 0 && y < 16) {
-            return new Box(x - 1, -1, x - 1, x + 1, 16, z + 1);
+            return new Box(x - 1, -1, z - 1, x + 1, 16, z + 1);
         } else {
-            return new Box(x - 1, y - 1, x - 1, x + 1, y + 1, z + 1);
+            return new Box(x - 1, y - 1, z - 1, x + 1, y + 1, z + 1);
         }
     }
 

--- a/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
@@ -349,8 +349,8 @@ public class VanillaWorldGenerator implements IWorldGenerator, IPreloadFailureDe
         try {
             WorldgenHangWatchdog.startWorldGen();
 
-            // Generate all relevant cubes and store them in an array cache
-            loader.cacheCubes(getCubesToGenerate(cx, cy, cz), Requirement.GENERATE);
+            // Cache the affected cubes for this vanilla chunk
+            loader.cacheCubes(getRelevantCubes(cx, cy, cz));
 
             if (cy >= 0 && cy < 16) {
                 for (int x = -1; x <= 1; x++) {
@@ -404,7 +404,7 @@ public class VanillaWorldGenerator implements IWorldGenerator, IPreloadFailureDe
     // private static final short[] CUBE_FLAGS = { Cube.POP_100, Cube.POP_010, Cube.POP_110, Cube.POP_001, Cube.POP_101,
     // Cube.POP_011, Cube.POP_111, };
 
-    private Box getCubesToGenerate(int x, int y, int z) {
+    private Box getRelevantCubes(int x, int y, int z) {
         if (y >= 0 && y < 16) {
             return new Box(x - 1, -1, z - 1, x + 1, 16, z + 1);
         } else {

--- a/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
@@ -69,6 +69,7 @@ import com.cardinalstar.cubicchunks.world.cube.blockview.IBlockView;
 import com.cardinalstar.cubicchunks.world.cube.blockview.UniformBlockView;
 import com.gtnewhorizon.gtnhlib.util.data.BlockMeta;
 import com.gtnewhorizon.gtnhlib.util.data.ImmutableBlockMeta;
+
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 


### PR DESCRIPTION
## Summary
This fixes a crash, a minor typo, and some lighting bugs when travelling at high speeds.

This crash is caused by BC robotics polling a chunk within the unload event, causing the chunk to reload. This periodically causes fastutils to fail when it rehashes a set in EFR. The fix is to post the event, then remove the chunk from the world, which better matches vanilla's behaviour.
https://discord.com/channels/181078474394566657/1415607665375313961/1529114252680626196

There was a minor typo in the getCubesToGenerate method, whose name is a misnomer. It was renamed to getRelevantCubes and the Requirement parameter was removed from cacheCubes since it was unused.

There were also two lighting bugs.

The first was sporadic unlit caves along chunk borders. Sometimes a cave near the surface would be half lit - the start was lit, but beyond a chunk border the light didn't propagate. Also, when the player moved very quickly (faster than the chunkgen could keep up) the chunks that generated under their feet would have black borders due to improper skylight propagation. These were both caused by pending lighting updates not running after the first skylight propagation ran. Draining the queue after doing the first skylight propagation caused the whole cube sync packet to send the proper light values to the client.

There was also unnecessary lighting checks along chunk borders even when the blocks are fully exposed to the sky. I added a condition to skip these lighting updates.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
