### PR TITLE
Load cubes when fetching tile entities from unloaded cubes

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/world/column/ColumnTileEntityMap.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/world/column/ColumnTileEntityMap.java
@@ -204,8 +204,8 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
     }
 
     @Override
-    public Collection<TileEntity> values() {
-        return new AbstractCollection<TileEntity>() {
+    public @NotNull Collection<TileEntity> values() {
+        return new AbstractCollection<>() {
 
             @Override
             public int size() {
@@ -224,17 +224,17 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
             }
 
             @Override
-            public Iterator<TileEntity> iterator() {
-                return new Iterator<TileEntity>() {
+            public @NotNull Iterator<TileEntity> iterator() {
+                return new Iterator<>() {
 
-                    Iterator<? extends ICube> cubes = column.getLoadedCubes()
+                    private final Iterator<? extends ICube> cubes = column.getLoadedCubes()
                         .iterator();
-                    Iterator<TileEntity> curIt = !cubes.hasNext() ? null
+                    private Iterator<TileEntity> curIt = !cubes.hasNext() ? null
                         : cubes.next()
                             .getTileEntityMap()
                             .values()
                             .iterator();
-                    TileEntity nextVal;
+                    private TileEntity nextVal;
 
                     @Override
                     public boolean hasNext() {
@@ -290,8 +290,8 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
     }
 
     @Override
-    public Set<Entry<ChunkPosition, TileEntity>> entrySet() {
-        return new AbstractSet<Entry<ChunkPosition, TileEntity>>() {
+    public @NotNull Set<Entry<ChunkPosition, TileEntity>> entrySet() {
+        return new AbstractSet<>() {
 
             @Override
             public int size() {
@@ -311,11 +311,11 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
             @Nonnull
             @Override
             public Iterator<Entry<ChunkPosition, TileEntity>> iterator() {
-                return new Iterator<Entry<ChunkPosition, TileEntity>>() {
+                return new Iterator<>() {
 
-                    Iterator<? extends ICube> cubes = column.getLoadedCubes()
+                    private final Iterator<? extends ICube> cubes = column.getLoadedCubes()
                         .iterator();
-                    Iterator<Entry<ChunkPosition, TileEntity>> curIt = !cubes.hasNext() ? null
+                    private Iterator<Entry<ChunkPosition, TileEntity>> curIt = !cubes.hasNext() ? null
                         : cubes.next()
                             .getTileEntityMap()
                             .entrySet()

--- a/src/main/java/com/cardinalstar/cubicchunks/world/column/ColumnTileEntityMap.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/world/column/ColumnTileEntityMap.java
@@ -77,10 +77,7 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
 
         int y = Coords.blockToCube(pos.chunkPosY);
 
-        // Use getLoadedCube to avoid loading or generating cubes.
-        // You almost never want to load chunks with this method, and you definitely never want to generate chunks with
-        // this method.
-        ICube cube = column.getLoadedCube(y);
+        ICube cube = column.getCube(y);
 
         return cube != null && cube.getTileEntityMap()
             .containsKey(o);
@@ -92,7 +89,7 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
             return false;
         }
         int y = Coords.blockToCube(((TileEntity) o).yCoord);
-        ICube cube = column.getLoadedCube(y);
+        ICube cube = column.getCube(y);
         assert cube != null : "Cube is null but tile entity in it exists!";
         return cube.getTileEntityMap()
             .containsValue(o);
@@ -107,10 +104,7 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
 
         int y = Coords.blockToCube(pos.chunkPosY);
 
-        // Use getLoadedCube to avoid loading or generating cubes.
-        // You almost never want to load chunks with this method, and you definitely never want to generate chunks with
-        // this method.
-        ICube cube = column.getLoadedCube(y);
+        ICube cube = column.getCube(y);
 
         return cube == null ? null
             : cube.getTileEntityMap()
@@ -134,10 +128,7 @@ public class ColumnTileEntityMap implements Map<ChunkPosition, TileEntity> {
 
         int y = Coords.blockToCube(pos.chunkPosY);
 
-        // Use getLoadedCube to avoid loading or generating cubes.
-        // You almost never want to load chunks with this method, and you definitely never want to generate chunks with
-        // this method.
-        ICube cube = column.getLoadedCube(y);
+        ICube cube = column.getCube(y);
 
         return cube == null ? null
             : cube.getTileEntityMap()


### PR DESCRIPTION
## Summary
There was an odd corruption bug related to GT pipes, but it also applied to some machines. It was caused by one cube remaining loaded while another unloads. When a pipe tried to push fluids into an unloaded cube, it would check for an existing tile in that position via `Chunk.func_150806_e`. Since the target cube was unloaded, it would see no tile. This is because I previously changed ColumnTileEntityMap to only check loaded cubes for tiles. Since `func_150806_e` saw no tiles in the location, it would then call `getBlock` to check if the position *should* have a tile. `getBlock` loads the tile, and returns `gt.blockmachines`. `hasTileEntity` returns true for the given meta, so `func_150806_e` creates a new (invalid) tile for the given meta and puts it in the TE map, inserting it into the cube. From that point on, the tile in that location is no longer valid.

There were two ways I could've fixed this. The first is what I chose to do - I restored ColumnTileEntityMap to its old behaviour of loading cubes. The other solution would be to no-op `func_150806_e` by returning null when the target cube was unloaded, but I figured this would cause similar issues so I went with the first solution.

fixes: https://github.com/GTNewHorizons/CubicChunks1710/issues/78

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
