### PR TITLE
Reconcile snow after column population

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
@@ -385,6 +385,11 @@ public class VanillaWorldGenerator implements IWorldGenerator, IPreloadFailureDe
                 }
             }
 
+            if (cy >= 0 && cy < 16) {
+                // A later neighboring population tile can grow leaves into this completed column after its snow pass.
+                reconcileSnowCover(cx, cz);
+            }
+
             for (Vector3ic v : getFullyPopulatedCubes(cx, cy, cz)) {
                 Cube center = loader.getCube(v.x(), v.y(), v.z(), Requirement.GENERATE);
 
@@ -435,6 +440,23 @@ public class VanillaWorldGenerator implements IWorldGenerator, IPreloadFailureDe
             for (int dz = 0; dz <= 1; dz++) {
                 for (int cubeY = 0; cubeY < 16; cubeY++) {
                     loader.getCube(columnX + dx, cubeY, columnZ + dz, Requirement.GENERATE);
+                }
+            }
+        }
+    }
+
+    private void reconcileSnowCover(int columnX, int columnZ) {
+        int minBlockX = Coords.cubeToMinBlock(columnX);
+        int minBlockZ = Coords.cubeToMinBlock(columnZ);
+
+        for (int dx = 0; dx < 16; dx++) {
+            for (int dz = 0; dz < 16; dz++) {
+                int blockX = minBlockX + dx;
+                int blockZ = minBlockZ + dz;
+                int precipitationY = world.getPrecipitationHeight(blockX, blockZ);
+
+                if (world.func_147478_e(blockX, precipitationY, blockZ, true)) {
+                    world.setBlock(blockX, precipitationY, blockZ, Blocks.snow_layer, 0, 2);
                 }
             }
         }


### PR DESCRIPTION
Fixes a bug where trees would only spawn with partial snow cover in snow biomes by running the snow population a second time. It does not fix it for giant Redwood trees, as those populate a massive area, but those are rare anyway.

<img width="1521" height="898" alt="image" src="https://github.com/user-attachments/assets/c51a8056-4b93-4b48-bb3d-b48379821974" />

