### PR TITLE
Fix void particles and default min height

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/CubicChunksConfig.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/CubicChunksConfig.java
@@ -120,7 +120,7 @@ public class CubicChunksConfig {
     @Config.LangKey("cubicchunks.config.default_min_height")
     @Config.Comment("World min height. Values that are not an integer multiple of 16 may cause unintended behavior")
     @Config.RangeInt(min = CubicChunks.MIN_SUPPORTED_BLOCK_Y, max = 0)
-    public static int defaultMinHeight = -(1 << 30);
+    public static int defaultMinHeight = 0;
 
     @Config.LangKey("cubicchunks.config.default_max_height")
     @Config.Comment("World max height. Values that are not an integer multiple of 16 may cause unintended behavior")

--- a/src/main/java/com/cardinalstar/cubicchunks/CubicChunksConfig.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/CubicChunksConfig.java
@@ -74,7 +74,7 @@ public class CubicChunksConfig {
         + "         0:bottom:-128, \n"
         + "         0:top:1024 \n"
         + "     >\n")
-    public static String[] dimensional_height_overrides = {};
+    public static String[] dimensional_height_overrides = { "0:bottom:-64" };
 
     @Config.LangKey("cubicchunks.config.vert_view_distance")
     @Config.Comment("Similar to Minecraft's view distance, only for vertical chunks. Automatically adjusted by vertical view distance slider on the"

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/client/MixinWorldClient.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/client/MixinWorldClient.java
@@ -96,7 +96,8 @@ public abstract class MixinWorldClient extends MixinWorld implements ICubicWorld
     @Definition(id = "nextInt", method = "Ljava/util/Random;nextInt(I)I")
     @Expression("this.rand.nextInt(8) > ?")
     @WrapOperation(method = "doVoidFogParticles", at = @At("MIXINEXTRAS:EXPRESSION"))
-    public boolean decreaseVoidParticleAmount(int ignored, int blockY, Operation<Boolean> original) {
-        return this.rand.nextInt(8) > Math.max(blockY, 4);
+    public boolean useMinimumHeightForVoidParticles(int randomValue, int blockY, Operation<Boolean> original) {
+        long relativeY = (long) blockY - this.getMinHeight();
+        return randomValue > Math.max(relativeY, 4L);
     }
 }


### PR DESCRIPTION
Changed the void particles to spawn at the configured minimum world height, also changed the default minimum height to be Y0 as this makes the most sense for most dims, currently falling out of a no bedrock dim like The End would never kill you and keep falling indefinitely because you would only get damaged 64 blocks below -(1 << 30)

Added a default override for the Overworld to use Y-64 as minimum height for easier testing of negative Y stuff, if any dims actually use below Y0 they should set it as override