### PR TITLE
Initialize client cubes before load events

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/client/CubeProviderClient.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/client/CubeProviderClient.java
@@ -36,7 +36,6 @@ import net.minecraftforge.event.world.ChunkEvent;
 
 import com.cardinalstar.cubicchunks.api.IColumn;
 import com.cardinalstar.cubicchunks.api.XYZMap;
-import com.cardinalstar.cubicchunks.api.event.CubeEvent;
 import com.cardinalstar.cubicchunks.mixin.api.ICubicWorldInternal;
 import com.cardinalstar.cubicchunks.mixin.early.client.IChunkProviderClient;
 import com.cardinalstar.cubicchunks.util.CubePos;
@@ -151,10 +150,6 @@ public class CubeProviderClient extends ChunkProviderClient implements ICubeProv
         cube = new Cube(column, pos.getY()); // auto added to column
         ((IColumn) column).addCube(cube);
         this.cubeMap.put(cube);
-        world.getLightingManager()
-            .onCubeLoad(cube);
-        cube.setCubeLoaded();
-        EVENT_BUS.post(new CubeEvent.Load(column.worldObj, cube));
         return cube;
     }
 

--- a/src/main/java/com/cardinalstar/cubicchunks/network/PacketEncoderCube.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/network/PacketEncoderCube.java
@@ -101,6 +101,9 @@ public class PacketEncoderCube extends CCPacketEncoder<PacketCube> {
 
         WorldEncoder.decodeCube(new CCPacketBuffer(Unpooled.wrappedBuffer(packet.data)), cube, world);
 
+        if (!cube.isCubeLoaded()) {
+            cube.onCubeLoad();
+        }
         cube.markForRenderUpdate();
     }
 }

--- a/src/main/java/com/cardinalstar/cubicchunks/network/WorldEncoder.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/network/WorldEncoder.java
@@ -20,8 +20,14 @@
  */
 package com.cardinalstar.cubicchunks.network;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.NibbleArray;
@@ -145,6 +151,8 @@ class WorldEncoder {
     static void decodeCube(CCPacketBuffer in, Cube cube, World world) {
         final boolean capi = Mods.ChunkAPI.isModLoaded();
 
+        cacheTileEntityBlockData(cube);
+
         int[] oldHeights = new int[Cube.SIZE * Cube.SIZE];
 
         byte[] buffer;
@@ -231,6 +239,81 @@ class WorldEncoder {
 
         if (!empty) {
             storage.removeInvalidBlocks();
+        }
+
+        refreshTileEntities(cube, world);
+
+        if (!empty) {
+            createTileEntities(cube, world, storage);
+        }
+    }
+
+    private static void cacheTileEntityBlockData(Cube cube) {
+        for (TileEntity tileEntity : cube.cubeTileEntityMap.values()) {
+            tileEntity.updateContainingBlockInfo();
+            tileEntity.getBlockMetadata();
+            tileEntity.getBlockType();
+        }
+    }
+
+    private static void refreshTileEntities(Cube cube, World world) {
+        List<TileEntity> invalidTileEntities = new ArrayList<>();
+
+        for (TileEntity tileEntity : cube.cubeTileEntityMap.values()) {
+            Block oldBlock = tileEntity.getBlockType();
+            int oldMetadata = tileEntity.blockMetadata;
+            Block newBlock = cube.getBlock(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+            int newMetadata = cube.getBlockMetadata(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+
+            if ((oldBlock != newBlock || oldMetadata != newMetadata) && tileEntity.shouldRefresh(
+                oldBlock,
+                newBlock,
+                oldMetadata,
+                newMetadata,
+                world,
+                tileEntity.xCoord,
+                tileEntity.yCoord,
+                tileEntity.zCoord)) {
+                invalidTileEntities.add(tileEntity);
+            }
+            tileEntity.updateContainingBlockInfo();
+        }
+
+        for (TileEntity tileEntity : invalidTileEntities) {
+            tileEntity.invalidate();
+        }
+    }
+
+    private static void createTileEntities(Cube cube, World world, ExtendedBlockStorage storage) {
+        int minBlockX = Coords.cubeToMinBlock(cube.getX());
+        int minBlockY = Coords.cubeToMinBlock(cube.getY());
+        int minBlockZ = Coords.cubeToMinBlock(cube.getZ());
+
+        for (int y = 0; y < Cube.SIZE; y++) {
+            int worldY = minBlockY + y;
+            for (int z = 0; z < Cube.SIZE; z++) {
+                for (int x = 0; x < Cube.SIZE; x++) {
+                    Block block = storage.getBlockByExtId(x, y, z);
+                    int metadata = storage.getExtBlockMetadata(x, y, z);
+                    if (!block.hasTileEntity(metadata)) {
+                        continue;
+                    }
+
+                    ChunkPosition pos = new ChunkPosition(x, worldY, z);
+                    TileEntity existing = cube.cubeTileEntityMap.get(pos);
+                    if (existing != null && !existing.isInvalid()) {
+                        continue;
+                    }
+
+                    TileEntity tileEntity = block.createTileEntity(world, metadata);
+                    if (tileEntity != null) {
+                        tileEntity.xCoord = minBlockX + x;
+                        tileEntity.yCoord = worldY;
+                        tileEntity.zCoord = minBlockZ + z;
+                        cube.addTileEntity(tileEntity);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed issue where tile entities such as chests would be invisible after reloading the world with Angelica. CubicChunks posted CubeEvent.Load before decoding the cube, causing Angelica to load and cache it before tile entities were initialized

Tile entities are now initialized before posting the load event