### PR TITLE
Clear cached client cube on unload

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/client/CubeProviderClient.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/client/CubeProviderClient.java
@@ -173,6 +173,9 @@ public class CubeProviderClient extends ChunkProviderClient implements ICubeProv
         cubeMap.remove(pos.getX(), pos.getY(), pos.getZ());
         cube.getColumn()
             .removeCube(pos.getY());
+        if (lastCube == cube) {
+            lastCube = null;
+        }
     }
 
     @Override

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
@@ -293,7 +293,15 @@ public class CubeLoaderServer implements ICubeLoader {
     public void unloadCube(int x, int y, int z) {
         CubeInfo info = cubes.remove(x, y, z);
 
-        if (info != null) info.onCubeUnloaded();
+        if (info != null) {
+            if (lastCube == info.cube) {
+                lastCube = null;
+            }
+            if (cache != null) {
+                cache.set(x, y, z, null);
+            }
+            info.onCubeUnloaded();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixed issue where the most recently unloaded cube could still be returned by getLoadedCube, because unloadCube removed it from cubeMap without invalidating lastCube. I found this while looking into #111, it would be hard to reproduce reliably ingame because the required sequence is unload cube A -> load cube A before any other cube lookup