### PR TITLE
Fix shaded LZ4 runtime and output allocation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -134,7 +134,7 @@ usesShadowedDependencies = true
 
 # If disabled, won't remove unused classes from shadowed dependencies. Some libraries use reflection to access
 # their own classes, making the minimization unreliable.
-minimizeShadowedDependencies = true
+minimizeShadowedDependencies = false
 
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CCNBTUtils.java
@@ -104,13 +104,13 @@ public class CCNBTUtils {
                     }
 
                     byte[] data = nos.toByteArray();
+                    var compressor = LZ4Factory.fastestInstance()
+                        .fastCompressor();
 
-                    ByteBuffer compressed = ByteBuffer.allocate(data.length + 8)
+                    ByteBuffer compressed = ByteBuffer.allocate(8 + compressor.maxCompressedLength(data.length))
                         .order(ByteOrder.LITTLE_ENDIAN);
 
-                    int compLen = LZ4Factory.fastestInstance()
-                        .fastCompressor()
-                        .compress(data, 0, data.length, compressed.array(), 8);
+                    int compLen = compressor.compress(data, 0, data.length, compressed.array(), 8);
 
                     compressed.putInt(0, LZ4_MAGIC_NUMBER);
                     compressed.putInt(4, data.length);


### PR DESCRIPTION
minimizeShadowedDependencies = true stips the LZ4 implementation classes reflectively from production builds, dev builds include that so maybe that is why it worked in your testing but not for Shadowreaper

also ByteBuffer.allocate(data.length + 8) can be too small because incompressible LZ4 output can be larger than the input