### PR TITLE
Fix client height bounds

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
@@ -72,6 +72,10 @@ public enum Mixins implements IMixins {
         .addCommonMixins("common.vanillaclient.MixinS01PacketJoinGame")
         .setPhase(Phase.EARLY)
         .setApplyIf(() -> true)),
+    MIXIN_S07PACKET_RESPAWN(new MixinBuilder("Giving respawn packets info to initialize cubicWorlds for clients.")
+        .addCommonMixins("common.vanillaclient.MixinS07PacketRespawn")
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> true)),
     MIXIN_OVERWORLD_GENERATOR(new MixinBuilder("Modify overworld chunk generator")
         .addCommonMixins("common.worldgen.MixinChunkProviderGenerate")
         .setPhase(Phase.EARLY)

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/client/MixinNetHandlerPlayClient.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/client/MixinNetHandlerPlayClient.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.network.play.server.S01PacketJoinGame;
+import net.minecraft.network.play.server.S07PacketRespawn;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.cardinalstar.cubicchunks.api.IntRange;
 import com.cardinalstar.cubicchunks.mixin.api.ICubicWorldInternal;
 import com.cardinalstar.cubicchunks.network.ICubicJoinGamePacket;
+import com.cardinalstar.cubicchunks.network.ICubicRespawnPacket;
 import com.llamalad7.mixinextras.expression.Definition;
 import com.llamalad7.mixinextras.expression.Expression;
 
@@ -39,6 +41,25 @@ public class MixinNetHandlerPlayClient {
                     cubicJoinGamePacket.cubicChunks$getMinGenerationHeight(),
                     cubicJoinGamePacket.cubicChunks$getMaxGenerationHeight()));
             // Update stale ViewFrustum/RenderChunk-related state, as it was previously set for non-CC world
+            Minecraft.getMinecraft().renderGlobal.setWorldAndLoadRenderers(clientWorldController);
+        }
+    }
+
+    @Definition(
+        id = "clientWorldController",
+        field = "Lnet/minecraft/client/network/NetHandlerPlayClient;clientWorldController:Lnet/minecraft/client/multiplayer/WorldClient;")
+    @Definition(id = "isRemote", field = "Lnet/minecraft/client/multiplayer/WorldClient;isRemote:Z")
+    @Expression("this.clientWorldController.isRemote = true")
+    @Inject(method = "handleRespawn", at = @At("MIXINEXTRAS:EXPRESSION"))
+    void initRespawnedClientCubicWorld(S07PacketRespawn packetIn, CallbackInfo ci) {
+        if (packetIn instanceof ICubicRespawnPacket cubicRespawnPacket) {
+            ((ICubicWorldInternal.Client) clientWorldController).initCubicWorldClient(
+                new IntRange(
+                    cubicRespawnPacket.cubicChunks$getMinHeight(),
+                    cubicRespawnPacket.cubicChunks$getMaxHeight()),
+                new IntRange(
+                    cubicRespawnPacket.cubicChunks$getMinGenerationHeight(),
+                    cubicRespawnPacket.cubicChunks$getMaxGenerationHeight()));
             Minecraft.getMinecraft().renderGlobal.setWorldAndLoadRenderers(clientWorldController);
         }
     }

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/client/MixinNetHandlerPlayClient.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/client/MixinNetHandlerPlayClient.java
@@ -52,15 +52,12 @@ public class MixinNetHandlerPlayClient {
     @Expression("this.clientWorldController.isRemote = true")
     @Inject(method = "handleRespawn", at = @At("MIXINEXTRAS:EXPRESSION"))
     void initRespawnedClientCubicWorld(S07PacketRespawn packetIn, CallbackInfo ci) {
-        if (packetIn instanceof ICubicRespawnPacket cubicRespawnPacket) {
-            ((ICubicWorldInternal.Client) clientWorldController).initCubicWorldClient(
-                new IntRange(
-                    cubicRespawnPacket.cubicChunks$getMinHeight(),
-                    cubicRespawnPacket.cubicChunks$getMaxHeight()),
-                new IntRange(
-                    cubicRespawnPacket.cubicChunks$getMinGenerationHeight(),
-                    cubicRespawnPacket.cubicChunks$getMaxGenerationHeight()));
-            Minecraft.getMinecraft().renderGlobal.setWorldAndLoadRenderers(clientWorldController);
-        }
+        ICubicRespawnPacket cubicRespawnPacket = (ICubicRespawnPacket) packetIn;
+        ((ICubicWorldInternal.Client) clientWorldController).initCubicWorldClient(
+            new IntRange(cubicRespawnPacket.cubicChunks$getMinHeight(), cubicRespawnPacket.cubicChunks$getMaxHeight()),
+            new IntRange(
+                cubicRespawnPacket.cubicChunks$getMinGenerationHeight(),
+                cubicRespawnPacket.cubicChunks$getMaxGenerationHeight()));
+        Minecraft.getMinecraft().renderGlobal.setWorldAndLoadRenderers(clientWorldController);
     }
 }

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinEntityLivingBase.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinEntityLivingBase.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.cardinalstar.cubicchunks.world.ICubicWorld;
 import com.llamalad7.mixinextras.expression.Definition;
 import com.llamalad7.mixinextras.expression.Expression;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -25,7 +26,10 @@ public abstract class MixinEntityLivingBase extends Entity {
         method = "moveEntityWithHeading",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;blockExists(III)Z"))
     public boolean fixBlockExists(World instance, int x, int y, int z) {
-        return instance.blockExists(x, MathHelper.floor_double(this.posY), z);
+        int blockY = MathHelper.floor_double(this.posY);
+        ICubicWorld cubicWorld = (ICubicWorld) instance;
+        return blockY < cubicWorld.getMinHeight() || blockY >= cubicWorld.getMaxHeight()
+            || instance.blockExists(x, blockY, z);
     }
 
     @Definition(id = "posY", field = "Lnet/minecraft/entity/EntityLivingBase;posY:D")

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/vanillaclient/MixinS07PacketRespawn.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/vanillaclient/MixinS07PacketRespawn.java
@@ -1,0 +1,110 @@
+package com.cardinalstar.cubicchunks.mixin.early.common.vanillaclient;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S07PacketRespawn;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.cardinalstar.cubicchunks.api.ICubicWorldServer;
+import com.cardinalstar.cubicchunks.network.ICubicRespawnPacket;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@Mixin(S07PacketRespawn.class)
+public class MixinS07PacketRespawn implements ICubicRespawnPacket {
+
+    @Unique
+    private int minHeight = 0;
+
+    @Unique
+    private int maxHeight = 256;
+
+    @Unique
+    private int minGenerationHeight = 0;
+
+    @Unique
+    private int maxGenerationHeight = 256;
+
+    @Inject(
+        method = "<init>(ILnet/minecraft/world/EnumDifficulty;Lnet/minecraft/world/WorldType;Lnet/minecraft/world/WorldSettings$GameType;)V",
+        at = @At("TAIL"))
+    private void cubicChunks$initHeightInfo(int dimension, EnumDifficulty difficulty, WorldType worldType,
+        WorldSettings.GameType gameType, CallbackInfo ci) {
+        MinecraftServer server = FMLCommonHandler.instance()
+            .getMinecraftServerInstance();
+        if (server == null) return;
+
+        WorldServer world = server.worldServerForDimension(dimension);
+        if (world instanceof ICubicWorldServer cubicWorld) {
+            cubicChunks$setHeightInfo(
+                cubicWorld.getMinHeight(),
+                cubicWorld.getMaxHeight(),
+                cubicWorld.getMinGenerationHeight(),
+                cubicWorld.getMaxGenerationHeight());
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Unique
+    @Override
+    public int cubicChunks$getMinHeight() {
+        return minHeight;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Unique
+    @Override
+    public int cubicChunks$getMaxHeight() {
+        return maxHeight;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Unique
+    @Override
+    public int cubicChunks$getMinGenerationHeight() {
+        return minGenerationHeight;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Unique
+    @Override
+    public int cubicChunks$getMaxGenerationHeight() {
+        return maxGenerationHeight;
+    }
+
+    @Unique
+    @Override
+    public void cubicChunks$setHeightInfo(int minHeight, int maxHeight, int minGenerationHeight,
+        int maxGenerationHeight) {
+        this.minHeight = minHeight;
+        this.maxHeight = maxHeight;
+        this.minGenerationHeight = minGenerationHeight;
+        this.maxGenerationHeight = maxGenerationHeight;
+    }
+
+    @Inject(method = "writePacketData", at = @At("TAIL"))
+    private void cubicChunks$writeHeightInfo(PacketBuffer data, CallbackInfo ci) {
+        data.writeInt(minHeight);
+        data.writeInt(maxHeight);
+        data.writeInt(minGenerationHeight);
+        data.writeInt(maxGenerationHeight);
+    }
+
+    @Inject(method = "readPacketData", at = @At("TAIL"))
+    private void cubicChunks$readHeightInfo(PacketBuffer data, CallbackInfo ci) {
+        if (data.readableBytes() < 16) return;
+
+        cubicChunks$setHeightInfo(data.readInt(), data.readInt(), data.readInt(), data.readInt());
+    }
+}

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/vanillaclient/MixinS07PacketRespawn.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/vanillaclient/MixinS07PacketRespawn.java
@@ -103,8 +103,6 @@ public class MixinS07PacketRespawn implements ICubicRespawnPacket {
 
     @Inject(method = "readPacketData", at = @At("TAIL"))
     private void cubicChunks$readHeightInfo(PacketBuffer data, CallbackInfo ci) {
-        if (data.readableBytes() < 16) return;
-
         cubicChunks$setHeightInfo(data.readInt(), data.readInt(), data.readInt(), data.readInt());
     }
 }

--- a/src/main/java/com/cardinalstar/cubicchunks/network/ICubicRespawnPacket.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/network/ICubicRespawnPacket.java
@@ -1,0 +1,14 @@
+package com.cardinalstar.cubicchunks.network;
+
+public interface ICubicRespawnPacket {
+
+    int cubicChunks$getMinHeight();
+
+    int cubicChunks$getMaxHeight();
+
+    int cubicChunks$getMinGenerationHeight();
+
+    int cubicChunks$getMaxGenerationHeight();
+
+    void cubicChunks$setHeightInfo(int minHeight, int maxHeight, int minGenerationHeight, int maxGenerationHeight);
+}


### PR DESCRIPTION
Fixes #110 by not treating positions outside the configured world bounds as unloaded terrain, which caused the client to permanently apply the vanilla missing-chunk fall speed clamp.

Also syncs world and generation height bounds through S07PacketRespawn. Previously respawning would cause dimensions to be 0...256 on the client side until relogging