### PR TITLE
Fix block interaction outside vanilla height limits

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
@@ -78,6 +78,8 @@ public enum Mixins implements IMixins {
         .setApplyIf(() -> true)),
     MIXIN_C08_HEIGHT_LIMITS(new MixinBuilder("Changing packet C08 to read and write full integer Y values.")
         .addCommonMixins("common.MixinC08PacketPlayerBlockPlacement")
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> true)),
     MIXIN_S07PACKET_RESPAWN(new MixinBuilder("Giving respawn packets info to initialize cubicWorlds for clients.")
         .addCommonMixins("common.vanillaclient.MixinS07PacketRespawn")
         .setPhase(Phase.EARLY)

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
@@ -72,6 +72,14 @@ public enum Mixins implements IMixins {
         .addCommonMixins("common.vanillaclient.MixinS01PacketJoinGame")
         .setPhase(Phase.EARLY)
         .setApplyIf(() -> true)),
+    MIXIN_C07_HEIGHT_LIMITS(new MixinBuilder("Changing packet C07 to read and write full integer Y values.")
+        .addCommonMixins("common.MixinC07PacketPlayerDigging")
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> true)),
+    MIXIN_C08_HEIGHT_LIMITS(new MixinBuilder("Changing packet C08 to read and write full integer Y values.")
+        .addCommonMixins("common.MixinC08PacketPlayerBlockPlacement")
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> true)),
     MIXIN_OVERWORLD_GENERATOR(new MixinBuilder("Modify overworld chunk generator")
         .addCommonMixins("common.worldgen.MixinChunkProviderGenerate")
         .setPhase(Phase.EARLY)

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinC07PacketPlayerDigging.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinC07PacketPlayerDigging.java
@@ -1,0 +1,44 @@
+package com.cardinalstar.cubicchunks.mixin.early.common;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.client.C07PacketPlayerDigging;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import io.netty.buffer.ByteBuf;
+
+@Mixin(C07PacketPlayerDigging.class)
+public class MixinC07PacketPlayerDigging {
+
+    @Shadow
+    private int field_149509_b;
+
+    @Redirect(
+        method = "readPacketData",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readUnsignedByte()S", ordinal = 1))
+    private short skipVanillaYRead(PacketBuffer data) {
+        return 0;
+    }
+
+    @Inject(
+        method = "readPacketData",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readInt()I", ordinal = 1))
+    private void readFullY(PacketBuffer data, CallbackInfo ci) {
+        this.field_149509_b = data.readInt();
+    }
+
+    @Redirect(
+        method = "writePacketData",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/network/PacketBuffer;writeByte(I)Lio/netty/buffer/ByteBuf;",
+            ordinal = 1))
+    private ByteBuf writeFullY(PacketBuffer data, int ignored) {
+        return data.writeInt(this.field_149509_b);
+    }
+}

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinC08PacketPlayerBlockPlacement.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinC08PacketPlayerBlockPlacement.java
@@ -1,0 +1,44 @@
+package com.cardinalstar.cubicchunks.mixin.early.common;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import io.netty.buffer.ByteBuf;
+
+@Mixin(C08PacketPlayerBlockPlacement.class)
+public class MixinC08PacketPlayerBlockPlacement {
+
+    @Shadow
+    private int field_149581_b;
+
+    @Redirect(
+        method = "readPacketData",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readUnsignedByte()S", ordinal = 0))
+    private short skipVanillaYRead(PacketBuffer data) {
+        return 0;
+    }
+
+    @Inject(
+        method = "readPacketData",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readInt()I", ordinal = 1))
+    private void readFullY(PacketBuffer data, CallbackInfo ci) {
+        this.field_149581_b = data.readInt();
+    }
+
+    @Redirect(
+        method = "writePacketData",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/network/PacketBuffer;writeByte(I)Lio/netty/buffer/ByteBuf;",
+            ordinal = 0))
+    private ByteBuf writeFullY(PacketBuffer data, int ignored) {
+        return data.writeInt(this.field_149581_b);
+    }
+}


### PR DESCRIPTION
C07PacketPlayerDigging and C08PacketPlayerBlockPlacement Y values were serialized as unsigned byte, causing beaking/placing blocks outside of 0...255 to not work on dedicated servers