### PR TITLE
Fix world effects outside vanilla height limits

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
@@ -72,6 +72,10 @@ public enum Mixins implements IMixins {
         .addCommonMixins("common.vanillaclient.MixinS01PacketJoinGame")
         .setPhase(Phase.EARLY)
         .setApplyIf(() -> true)),
+    MIXIN_S28_HEIGHT_LIMITS(new MixinBuilder("Changing packet S28 to read and write full integer Y values.")
+        .addCommonMixins("common.MixinS28PacketEffect")
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> true)),
     MIXIN_S07PACKET_RESPAWN(new MixinBuilder("Giving respawn packets info to initialize cubicWorlds for clients.")
         .addCommonMixins("common.vanillaclient.MixinS07PacketRespawn")
         .setPhase(Phase.EARLY)

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinS28PacketEffect.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinS28PacketEffect.java
@@ -1,0 +1,43 @@
+package com.cardinalstar.cubicchunks.mixin.early.common;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S28PacketEffect;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import io.netty.buffer.ByteBuf;
+
+@Mixin(S28PacketEffect.class)
+public class MixinS28PacketEffect {
+
+    @Shadow
+    private int field_149247_d;
+
+    @Redirect(
+        method = "readPacketData",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readByte()B"))
+    private byte skipVanillaYRead(PacketBuffer data) {
+        return 0;
+    }
+
+    @Inject(
+        method = "readPacketData",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readInt()I", ordinal = 2))
+    private void readFullY(PacketBuffer data, CallbackInfo ci) {
+        this.field_149247_d = data.readInt();
+    }
+
+    @Redirect(
+        method = "writePacketData",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/network/PacketBuffer;writeByte(I)Lio/netty/buffer/ByteBuf;"))
+    private ByteBuf writeFullY(PacketBuffer data, int ignored) {
+        return data.writeInt(this.field_149247_d);
+    }
+}


### PR DESCRIPTION
S28PacketEffect was serialized as unsigned byte, causing splash potion particles outside of 0...255 to not work on dedicated servers