### PR TITLE
Revalidate GC candidates before unloading

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,7 +1,10 @@
-
 //test {
 //    useJUnitPlatform()
 //    testLogging {
 //        events "passed", "skipped", "failed"
 //    }
 //}
+
+test {
+    useJUnitPlatform()
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -54,4 +54,6 @@ dependencies {
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.111-GTNH:dev")
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+    testRuntimeOnly('it.unimi.dsi:fastutil:8.5.18')
 }

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
@@ -55,6 +55,9 @@ public class CubeLoaderServer implements ICubeLoader {
     private final XYZMap<CubeInfo> cubes = new XYZMap<>();
     private final XZMap<ColumnInfo> columns = new XZMap<>();
 
+    // GC is server-thread confined. Event callbacks may reenter loading/GC synchronously.
+    private boolean gcRunning;
+    private int activeLoadCalls;
     private int pauseLoadCalls;
     private final List<Pair<Cube, CubeInitLevel>> pendingCubeGenerates = new ArrayList<>();
     private final List<Cube> pendingCubeLoads = new ArrayList<>();
@@ -128,24 +131,49 @@ public class CubeLoaderServer implements ICubeLoader {
         return column != null ? column.column : null;
     }
 
-    private void unloadColumn(ColumnInfo column) {
-        if (!column.containedCubes.isEmpty()) {
-            throw new IllegalStateException("Cannot unload column that still contains cubes");
+    private boolean canUnloadColumn(ColumnInfo info, CubicPlayerManager players) {
+        if (pauseLoadCalls > 0 || activeLoadCalls > 0) return false;
+        if (columns.get(info.getX(), info.getZ()) != info || info.column == null) return false;
+        // Check both indexes: do not destroy resident cubes to make a stale candidate fit.
+        if (!info.containedCubes.isEmpty() || ((IColumn) info.column).hasLoadedCubes()) return false;
+        if (ForgeChunkManager.getPersistentChunksFor(world)
+            .containsKey(info.pos)) return false;
+        return !players.func_152621_a(info.getX(), info.getZ());
+    }
+
+    private boolean tryUnloadColumn(ColumnInfo info, CubicPlayerManager players) {
+        if (!canUnloadColumn(info, players)) return false;
+        boolean removed = false;
+        try {
+            info.column.onChunkUnload();
+            // ChunkEvent.Unload handlers may have loaded cubes or acquired tickets/watchers.
+            if (!canUnloadColumn(info, players)) return false;
+            // Keep the live indexes until serialization succeeds. SaveNBT is another callback boundary.
+            cubeIO.saveColumn(info.pos, info.column);
+            if (!canUnloadColumn(info, players)) return false;
+            columns.remove(info);
+            removed = true;
+            callback.onColumnUnloaded(info.column);
+            return true;
+        } finally {
+            if (!removed && columns.get(info.getX(), info.getZ()) == info && !info.column.isChunkLoaded) {
+                // Balance the unload notification, but do NOT insert the same column into the provider again.
+                info.column.isModified = true;
+                info.column.onChunkLoad();
+            }
         }
-
-        column.column.onChunkUnload();
-
-        for (var cube : new ArrayList<>(column.containedCubes)) {
-            cube.onCubeUnloaded();
-            cubes.remove(cube);
-        }
-
-        columns.remove(column);
-
-        column.onColumnUnloaded();
     }
 
     private ColumnInfo getColumnInfo(int x, int z, Requirement effort) {
+        activeLoadCalls++;
+        try {
+            return getColumnInfoInternal(x, z, effort);
+        } finally {
+            activeLoadCalls--;
+        }
+    }
+
+    private ColumnInfo getColumnInfoInternal(int x, int z, Requirement effort) {
         ColumnInfo column = columns.get(x, z);
 
         if (effort == Requirement.GET_CACHED) return column;
@@ -205,6 +233,15 @@ public class CubeLoaderServer implements ICubeLoader {
 
     @Override
     public Cube getCube(int x, int y, int z, Requirement effort) {
+        activeLoadCalls++;
+        try {
+            return getCubeInternal(x, y, z, effort);
+        } finally {
+            activeLoadCalls--;
+        }
+    }
+
+    private Cube getCubeInternal(int x, int y, int z, Requirement effort) {
         if (cache != null) {
             Cube cube = cache.get(x, y, z);
 
@@ -212,6 +249,10 @@ public class CubeLoaderServer implements ICubeLoader {
                 .ordinal()
                 >= CubeInitLevel.fromRequirement(effort)
                     .ordinal()) {
+                if (effort != Requirement.GET_CACHED) {
+                    CubeInfo cachedInfo = cubes.get(x, y, z);
+                    if (cachedInfo != null && cachedInfo.cube == cube) cachedInfo.lastAccess = now;
+                }
                 return cube;
             }
         }
@@ -221,7 +262,10 @@ public class CubeLoaderServer implements ICubeLoader {
         Cube loaded = cubeInfo != null ? cubeInfo.cube : null;
 
         // Don't need to do anything because the cube is already initialized to the requested level
-        if (loaded != null && cubeInfo.isInitedTo(effort)) return loaded;
+        if (loaded != null && cubeInfo.isInitedTo(effort)) {
+            if (effort != Requirement.GET_CACHED) cubeInfo.lastAccess = now;
+            return loaded;
+        }
 
         if (effort == Requirement.GET_CACHED) return null;
 
@@ -371,10 +415,37 @@ public class CubeLoaderServer implements ICubeLoader {
 
     @Override
     public void doGC() {
+        if (gcRunning || activeLoadCalls > 0
+            || pauseLoadCalls > 0
+            || !pendingColumnLoads.isEmpty()
+            || !pendingCubeLoads.isEmpty()
+            || !pendingCubeGenerates.isEmpty()) return;
+        gcRunning = true;
+        try {
+            collectGarbage();
+        } finally {
+            gcRunning = false;
+        }
+    }
+
+    private boolean canUnloadCube(CubeInfo info, CubicPlayerManager players, long expiry) {
+        Cube cube = info.cube;
+        if (cube == null || info.generating || info.lastAccess > expiry) return false;
+        if (cubes.get(info.getX(), info.getY(), info.getZ()) != info) return false;
+        if (ForgeChunkManager.getPersistentChunksFor(world)
+            .containsKey(
+                cube.getColumn()
+                    .getChunkCoordIntPair()))
+            return false;
+        return !players.isCubeWatched(info.getX(), info.getY(), info.getZ()) && cube.getTickets()
+            .canUnload();
+    }
+
+    private void collectGarbage() {
         var persistentChunks = ForgeChunkManager.getPersistentChunksFor(world);
         CubicPlayerManager playerManager = (CubicPlayerManager) world.getPlayerManager();
 
-        List<CubePos> pendingCubeUnloads = new ArrayList<>();
+        List<CubeInfo> pendingCubeUnloads = new ArrayList<>();
 
         int startCubes = cubes.getSize();
         int startCols = columns.getSize();
@@ -384,7 +455,7 @@ public class CubeLoaderServer implements ICubeLoader {
         for (CubeInfo cubeInfo : cubes) {
             Cube cube = cubeInfo.cube;
 
-            if (cube == null || cubeInfo.lastAccess > expiry) continue;
+            if (cube == null || cubeInfo.generating || cubeInfo.lastAccess > expiry) continue;
 
             if (persistentChunks.containsKey(
                 cube.getColumn()
@@ -395,15 +466,17 @@ public class CubeLoaderServer implements ICubeLoader {
 
             if (cube.getTickets()
                 .canUnload()) {
-                pendingCubeUnloads.add(cubeInfo.pos);
+                pendingCubeUnloads.add(cubeInfo);
             }
         }
 
-        for (CubePos pos : pendingCubeUnloads) {
-            unloadCube(pos.getX(), pos.getY(), pos.getZ());
+        int removedCubes = 0;
+        for (CubeInfo info : pendingCubeUnloads) {
+            // Earlier unload callbacks can replace, access or pin a later candidate.
+            if (!canUnloadCube(info, playerManager, expiry)) continue;
+            unloadCube(info.getX(), info.getY(), info.getZ());
+            removedCubes++;
         }
-
-        int autoCols = columns.getSize();
 
         List<ColumnInfo> pendingColumnUnloads = new ArrayList<>();
 
@@ -415,7 +488,7 @@ public class CubeLoaderServer implements ICubeLoader {
             if (persistentChunks.containsKey(columnInfo.pos)) continue;
 
             // It has loaded Cubes in it (Cubes are to Columns, as tickets are to Cubes... in a way)
-            if (!columnInfo.containedCubes.isEmpty()) continue;;
+            if (!columnInfo.containedCubes.isEmpty() || ((IColumn) column).hasLoadedCubes()) continue;
 
             // PlayerChunkMap may contain reference to a column that for a while doesn't yet have any cubes generated
             if (playerManager.func_152621_a(column.xPosition, column.zPosition)) continue;
@@ -423,19 +496,20 @@ public class CubeLoaderServer implements ICubeLoader {
             pendingColumnUnloads.add(columnInfo);
         }
 
+        int removedColumns = 0;
         for (ColumnInfo column : pendingColumnUnloads) {
-            unloadColumn(column);
+            if (tryUnloadColumn(column, playerManager)) removedColumns++;
         }
 
         CubicChunks.LOGGER.trace(
-            "Garbage collected {} columns ({} -> {}) and {} cubes ({} -> {}). Removed {} columns automatically because they were empty.",
-            pendingColumnUnloads.size(),
+            "Garbage collected {} columns ({} -> {}) and {} cubes ({} -> {}); deferred {} stale column candidates.",
+            removedColumns,
             startCols,
             columns.getSize(),
-            pendingCubeUnloads.size(),
+            removedCubes,
             startCubes,
             cubes.getSize(),
-            startCols - autoCols);
+            pendingColumnUnloads.size() - removedColumns);
     }
 
     @Override
@@ -644,13 +718,6 @@ public class CubeLoaderServer implements ICubeLoader {
             invokeLoadCallback(column);
         }
 
-        public void onColumnUnloaded() {
-            try {
-                cubeIO.saveColumn(pos, column);
-            } finally {
-                callback.onColumnUnloaded(column);
-            }
-        }
     }
 
     private class CubeInfo implements XYZAddressable {
@@ -940,9 +1007,8 @@ public class CubeLoaderServer implements ICubeLoader {
             cube.onCubeUnload();
             callback.onCubeUnloaded(cube);
 
-            if (column.containedCubes.isEmpty()) {
-                unloadColumn(column);
-            }
+            // Column collection is a separate guarded GC phase. A cube unload callback can load
+            // another cube, watch this column or force it; never recursively detach it here.
         }
 
         private void ensureColumn(Requirement effort) {

--- a/src/test/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderGcRegressionTest.java
+++ b/src/test/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderGcRegressionTest.java
@@ -1,0 +1,373 @@
+package com.cardinalstar.cubicchunks.server.chunkio;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+
+import org.junit.jupiter.api.Test;
+
+import com.cardinalstar.cubicchunks.api.XYZMap;
+import com.cardinalstar.cubicchunks.api.XZMap;
+import com.cardinalstar.cubicchunks.server.CubicPlayerManager;
+import com.cardinalstar.cubicchunks.util.CubePos;
+import com.cardinalstar.cubicchunks.world.column.EmptyColumn;
+import com.cardinalstar.cubicchunks.world.cube.Cube;
+
+/** Actual loader code with inert world/IO fixtures: no game saves or network. */
+class CubeLoaderGcRegressionTest {
+
+    static Object allocate(Class<?> c) throws Exception {
+        Class<?> u = Class.forName("sun.misc.Unsafe");
+        Field f = u.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        return u.getMethod("allocateInstance", Class.class)
+            .invoke(f.get(null), c);
+    }
+
+    static Field field(Class<?> c, String name) throws Exception {
+        while (c != null) {
+            try {
+                Field f = c.getDeclaredField(name);
+                f.setAccessible(true);
+                return f;
+            } catch (NoSuchFieldException e) {
+                c = c.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+
+    static void set(Object o, String n, Object v) throws Exception {
+        field(o.getClass(), n).set(o, v);
+    }
+
+    static Object get(Object o, String n) throws Exception {
+        return field(o.getClass(), n).get(o);
+    }
+
+    private static class Manager extends CubicPlayerManager {
+
+        Set<Integer> watched;
+
+        Manager() {
+            super(null);
+        }
+
+        @Override
+        public boolean func_152621_a(int x, int z) {
+            return watched.contains(x);
+        }
+
+        @Override
+        public boolean isCubeWatched(int x, int y, int z) {
+            return watched.contains(x);
+        }
+    }
+
+    private static class Column extends EmptyColumn {
+
+        Map<Integer, Cube> resident;
+        Runnable unloading;
+        int unloads, loads;
+
+        Column() {
+            super(null, 0, 0);
+        }
+
+        @Override
+        public boolean hasLoadedCubes() {
+            return !resident.isEmpty();
+        }
+
+        @Override
+        public Collection<? extends Cube> getLoadedCubes() {
+            return resident.values();
+        }
+
+        @Override
+        public Cube getLoadedCube(int y) {
+            return resident.get(y);
+        }
+
+        @Override
+        public void addCube(Cube c) {
+            resident.put(c.getY(), c);
+        }
+
+        @Override
+        public Cube removeCube(int y) {
+            return resident.remove(y);
+        }
+
+        @Override
+        public void onChunkLoad() {
+            isChunkLoaded = true;
+            loads++;
+        }
+
+        @Override
+        public void onChunkUnload() {
+            isChunkLoaded = false;
+            unloads++;
+            if (unloading != null) unloading.run();
+        }
+    }
+
+    private static class TestCube extends Cube {
+
+        int unloads;
+
+        TestCube(Column column) {
+            super(
+                null,
+                null,
+                column,
+                new CubePos(column.xPosition, 3, 0),
+                null,
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                null);
+        }
+
+        @Override
+        public void onCubeUnload() {
+            unloads++;
+        }
+    }
+
+    private static class Fixture {
+
+        CubeLoaderServer loader;
+        Manager manager;
+        XZMap columns;
+        Class<?> ci = Class.forName(CubeLoaderServer.class.getName() + "$ColumnInfo");
+        Class<?> qi = Class.forName(CubeLoaderServer.class.getName() + "$CubeInfo");
+        int saves, callbacks;
+        Runnable onSave;
+        boolean failSave;
+
+        Fixture() throws Exception {
+            loader = (CubeLoaderServer) allocate(CubeLoaderServer.class);
+            manager = (Manager) allocate(Manager.class);
+            manager.watched = new HashSet<>();
+            WorldServer world = (WorldServer) allocate(WorldServer.class);
+            set(world, "thePlayerManager", manager);
+            set(loader, "world", world);
+            columns = new XZMap();
+            set(loader, "columns", columns);
+            set(loader, "cubes", new XYZMap<>());
+            set(loader, "pendingCubeLoads", new ArrayList<>());
+            set(loader, "pendingColumnLoads", new ArrayList<>());
+            set(loader, "pendingCubeGenerates", new ArrayList<>());
+            set(
+                loader,
+                "cubeIO",
+                Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { ICubeIO.class }, (p, m, a) -> {
+                    if (m.getName()
+                        .equals("saveColumn")) {
+                        saves++;
+                        if (onSave != null) onSave.run();
+                        if (failSave) throw new IllegalStateException("fixture save failure");
+                    }
+                    return null;
+                }));
+            set(loader, "callback", new CubeLoaderCallback() {
+
+                @Override
+                public void onColumnUnloaded(Chunk c) {
+                    callbacks++;
+                }
+            });
+        }
+
+        Object column(int x) throws Exception {
+            Column c = (Column) allocate(Column.class);
+            set(c, "xPosition", x);
+            set(c, "zPosition", 0);
+            c.resident = new HashMap<>();
+            c.isChunkLoaded = true;
+            Constructor<?> ctor = ci.getDeclaredConstructor(CubeLoaderServer.class, int.class, int.class);
+            ctor.setAccessible(true);
+            Object info = ctor.newInstance(loader, x, 0);
+            set(info, "column", c);
+            columns.put((com.cardinalstar.cubicchunks.util.XZAddressable) info);
+            return info;
+        }
+
+        Column body(Object info) {
+            try {
+                return (Column) get(info, "column");
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        void refill(Object info) {
+            try {
+                Column c = body(info);
+                TestCube cube = new TestCube(c);
+                c.addCube(cube);
+                Constructor<?> ctor = qi
+                    .getDeclaredConstructor(CubeLoaderServer.class, int.class, int.class, int.class);
+                ctor.setAccessible(true);
+                Object cubeInfo = ctor.newInstance(loader, c.xPosition, 3, 0);
+                set(cubeInfo, "cube", cube);
+                set(cubeInfo, "column", info);
+                ((Set) get(info, "containedCubes")).add(cubeInfo);
+                ((XYZMap) get(loader, "cubes")).put((com.cardinalstar.cubicchunks.api.XYZAddressable) cubeInfo);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        List<Object> order() {
+            List<Object> out = new ArrayList<>();
+            for (Object c : columns) out.add(c);
+            return out;
+        }
+    }
+
+    @Test
+    void queuedColumnRefilledByEarlierUnloadIsDeferred() throws Exception {
+        Fixture f = new Fixture();
+        f.column(201);
+        f.column(202);
+        List<Object> order = f.order();
+        Object first = order.get(0), later = order.get(1);
+        f.body(first).unloading = () -> f.refill(later);
+        assertDoesNotThrow(f.loader::doGC);
+        assertSame(later, f.columns.get(f.body(later).xPosition, 0));
+        assertTrue(f.body(later).isChunkLoaded);
+        assertEquals(0, f.body(later).unloads);
+        assertEquals(1, f.callbacks);
+    }
+
+    @Test
+    void sameColumnRefilledDuringUnloadKeepsCubesAndLoadedState() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(210);
+        f.body(c).unloading = () -> f.refill(c);
+        assertDoesNotThrow(f.loader::doGC);
+        assertSame(c, f.columns.get(210, 0));
+        assertTrue(f.body(c).isChunkLoaded);
+        assertEquals(1, f.body(c).loads);
+        assertEquals(1, f.body(c).resident.size());
+        assertEquals(
+            0,
+            ((TestCube) f.body(c)
+                .getLoadedCube(3)).unloads);
+        assertEquals(0, f.callbacks);
+    }
+
+    @Test
+    void columnWatchedAfterSelectionIsDeferred() throws Exception {
+        Fixture f = new Fixture();
+        f.column(211);
+        f.column(212);
+        List<Object> order = f.order();
+        Object later = order.get(1);
+        f.body(order.get(0)).unloading = () -> f.manager.watched.add(f.body(later).xPosition);
+        f.loader.doGC();
+        assertSame(later, f.columns.get(f.body(later).xPosition, 0));
+        assertEquals(0, f.body(later).unloads);
+    }
+
+    @Test
+    void pendingLoadCallbacksPreventCollection() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(220);
+        f.loader.pauseLoadCalls();
+        f.loader.doGC();
+        assertSame(c, f.columns.get(220, 0));
+        assertEquals(0, f.callbacks);
+        f.loader.unpauseLoadCalls();
+        f.loader.doGC();
+        assertNull(f.columns.get(220, 0));
+    }
+
+    @Test
+    void nestedCollectionDoesNotRepeatUnloadEvents() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(230);
+        f.body(c).unloading = f.loader::doGC;
+        assertDoesNotThrow(f.loader::doGC);
+        assertEquals(1, f.body(c).unloads);
+        assertEquals(1, f.callbacks);
+    }
+
+    @Test
+    void savingRefillKeepsColumnIndexed() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(240);
+        f.onSave = () -> f.refill(c);
+        f.loader.doGC();
+        assertSame(c, f.columns.get(240, 0));
+        assertTrue(f.body(c).isChunkLoaded);
+        assertEquals(0, f.callbacks);
+        assertTrue(f.body(c).isModified);
+    }
+
+    @Test
+    void activeInitializationDefersGcAndThenReleasesIt() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(280);
+        set(f.loader, "activeLoadCalls", 1);
+        f.loader.doGC();
+        assertSame(c, f.columns.get(280, 0));
+        set(f.loader, "activeLoadCalls", 0);
+        f.loader.doGC();
+        assertNull(f.columns.get(280, 0));
+    }
+
+    @Test
+    void saveFailurePropagatesWithoutDetachingColumn() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(250);
+        f.failSave = true;
+        IllegalStateException ex = assertThrows(IllegalStateException.class, f.loader::doGC);
+        assertEquals("fixture save failure", ex.getMessage());
+        assertSame(c, f.columns.get(250, 0));
+        assertTrue(f.body(c).isChunkLoaded);
+        assertEquals(0, f.callbacks);
+        f.failSave = false;
+        f.loader.doGC();
+        assertNull(f.columns.get(250, 0));
+    }
+
+    @Test
+    void ordinaryEmptyColumnIsSavedAndRemovedOnce() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(260);
+        f.loader.doGC();
+        f.loader.doGC();
+        assertNull(f.columns.get(260, 0));
+        assertEquals(1, f.saves);
+        assertEquals(1, f.callbacks);
+        assertEquals(1, f.body(c).unloads);
+    }
+
+    @Test
+    void physicalResidentCubeProtectsColumnEvenWithoutLoaderEntry() throws Exception {
+        Fixture f = new Fixture();
+        Object c = f.column(270);
+        f.body(c)
+            .addCube(new TestCube(f.body(c)));
+        f.loader.doGC();
+        assertSame(c, f.columns.get(270, 0));
+        assertTrue(f.body(c).isChunkLoaded);
+        assertEquals(0, f.callbacks);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a stale-candidate race/reentrancy problem in `CubeLoaderServer.doGC()`.

A cube or column can be selected as unloadable during the first GC scan, then become live again while an earlier unload/save callback runs. The old code later consumes the stale candidate without revalidating it. For columns this can end in:

```text
java.lang.IllegalStateException: Cannot unload column that still contains cubes
    at CubeLoaderServer.unloadColumn(...)
    at CubeLoaderServer.doGC(...)
```

The failure was reproduced with synchronous callbacks on the server thread; it does not require a cross-thread data race.
## Changes

- Revalidate cube candidates immediately before unloading them.
- Revalidate column identity, resident cubes, tickets/watchers, and persistent-chunk state before unload.
- Revalidate again after `ChunkEvent.Unload` and after column serialization/SaveNBT callbacks.
- Keep column indexes attached until serialization succeeds.
- Restore a column to loaded/dirty state when a callback makes the candidate live again.
- Defer nested GC and GC while load initialization/callbacks are active.
- Update `lastAccess` when an already-loaded cube is requested with a non-`GET_CACHED` requirement, so a callback access can invalidate a previously selected GC candidate.
- Collect columns in a separate guarded phase instead of recursively detaching a column while unloading its last cube.
## Regression coverage

Adds `CubeLoaderGcRegressionTest` with focused cases for:

- a later queued column being refilled by an earlier unload callback;
- the same column being refilled during its unload event;
- a column becoming watched after candidate selection;
- paused/active load initialization deferring collection;
- nested/reentrant GC;
- SaveNBT callbacks repopulating a column;
- save failures preserving indexes and propagating the error;
- ordinary empty-column collection remaining one-shot;
- physical resident cubes protecting a column even if loader bookkeeping is stale.

The test uses the real `CubeLoaderServer` implementation with inert world/IO fixtures; no world or protocol format is changed.
## Validation

Ported onto current upstream `master` (`2a3f7bbe`, after #116/#118/#119).

```text
./gradlew spotlessApply check assemble
BUILD SUCCESSFUL
```

`CubeLoaderGcRegressionTest`: 10 tests, 0 failures, 0 errors, 0 skipped.

This PR is intentionally limited to the GC/unload fix and the minimum test-task runtime configuration. It does not include Crucible compatibility, proxy/session changes, Angelica integration, or other changes from the downstream fork.
